### PR TITLE
Return error on init failure

### DIFF
--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -8,6 +8,9 @@ import (
 	"github.com/schroedinger-Hat/Daje/internal/config"
 )
 
+// initEmptyDaje is a hook to allow replacing the initialization logic in tests.
+var initEmptyDaje = config.InitEmptyDaje
+
 func NewCmdInit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [flags]",
@@ -26,9 +29,9 @@ func submitAction() error {
 		return nil
 	}
 
-	err := config.InitEmptyDaje()
+	err := initEmptyDaje()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	fmt.Println("Daje has been initialized successfully!")

--- a/pkg/cmd/init/init_test.go
+++ b/pkg/cmd/init/init_test.go
@@ -1,0 +1,31 @@
+package init
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/schroedinger-Hat/Daje/constants"
+	"github.com/schroedinger-Hat/Daje/internal/config"
+)
+
+func TestSubmitActionReturnsErrorOnInitFailure(t *testing.T) {
+	// Ensure daje folder does not exist
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("unable to get current user: %v", err)
+	}
+	dajePath := filepath.Join(currentUser.HomeDir, constants.DajeDotFile)
+	os.RemoveAll(dajePath)
+
+	expectedErr := errors.New("init failed")
+	initEmptyDaje = func() error { return expectedErr }
+	defer func() { initEmptyDaje = config.InitEmptyDaje }()
+
+	err = submitAction()
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- propagate errors from initialization
- add test verifying failed initialization is returned as error

## Testing
- `go vet ./...`
- `go test ./...`
